### PR TITLE
Added a way to switch the URL to https

### DIFF
--- a/Resources/Public/js/tev-glossary.js
+++ b/Resources/Public/js/tev-glossary.js
@@ -16,6 +16,11 @@
         }
 
         this.options = $.extend(defaults, options)
+        
+        // If the window is in https, set the URL to make an https request instead of http
+        if(window.location.protocol === 'https:') {
+            this.options.url = this.options.url.replace(/^http:\/\//i, 'https://');
+        }
     }
 
     /*


### PR DESCRIPTION
Tracker Issue: https://tracker.3ev.info/issues/17520

This is to allow the glossary to support HTTPs pages without flagging security issues